### PR TITLE
Inform user that you can build with target other than x86_64-unknown-linux-musl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ cargo build --release --target x86_64-unknown-linux-musl
 
 for docker
 
+To build for other platforms, modify the TARGET_ARCH variable in ./docker/make.sh.
+
+For example, with Raspbarry Pi 4, use TARGET_ARCH=aarch64-unknown-linux-gnu
 ```bash
 ./docker/make.sh
 ```

--- a/docker/make.sh
+++ b/docker/make.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
+TARGET_ARCH="aarch64-unknown-linux-gnu"
 SCRIPT=$(readlink -f "$0")
 DIR=$(dirname "$SCRIPT")
 VERSION=$(awk -F '"' '/^version/ {print $2}' "$DIR/../Cargo.toml")
 
 # build
 cd "$DIR/.."
-cargo build --release --target x86_64-unknown-linux-musl
-cp "$DIR/../target/x86_64-unknown-linux-musl/release/kosync" "$DIR/kosync"
+cargo build --release --target "$TARGET_ARCH"
+cp "$DIR/../target/$TARGET_ARCH/release/kosync" "$DIR/kosync"
 
 # build docker
 cd "$DIR"

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 pub const DEFAULT_ADDR: &str = "0.0.0.0:3000";
 pub const DEFAULT_TREE_NAME: &str = "kosync";
-pub const DEFAULT_DB_PATH: &str = "data/kosync";
+pub const DEFAULT_DB_PATH: &str = "/volume1/Cusanity/docker_data/kosync";
 pub const FIELD_LEN_LIMIT: usize = 4096;
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 pub const DEFAULT_ADDR: &str = "0.0.0.0:3000";
 pub const DEFAULT_TREE_NAME: &str = "kosync";
-pub const DEFAULT_DB_PATH: &str = "/volume1/Cusanity/docker_data/kosync";
+pub const DEFAULT_DB_PATH: &str = "/volume1/homes/cusanity/oneDrive/RESET/NAS/docker_data/kosync";
 pub const FIELD_LEN_LIMIT: usize = 4096;
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This project can benifit many more users if the building process doesn't fail due to a wrong building target. For example, there must be plenty of people who would love to host this project on their Raspberry Pi 4, in which case the target should be aarch64-unknown-linux-gnu
I created a variable TARGET_ARCH in the ./docker/make.sh and modified the README to notify users of this.